### PR TITLE
fix: タグ整理時に重複タグがあるとクラッシュするケース

### DIFF
--- a/src/TagListHandler.cpp
+++ b/src/TagListHandler.cpp
@@ -275,12 +275,18 @@ void TagListHandler::SortTags(BooruPrompter* pThis) {
 		}
 
 		// 単独タグの削除（重複オブジェクトがある場合）
-		for (auto it = tagList.begin(); it != tagList.end(); ++it) {
+		for (auto it = tagList.begin(); it != tagList.end(); ) {
 			if (it->second.size() > 1) {
 				erase_if(it->second, [](const Tag& tag) {
 					return tag.tag.find_last_of(' ') == std::string::npos;
 					});
+				// 削除後に空になったエントリを削除
+				if (it->second.empty()) {
+					it = tagList.erase(it);
+					continue;
+				}
 			}
+			++it;
 		}
 
 		// 各グループ内でソート

--- a/test/TagListHandlerTest.cpp
+++ b/test/TagListHandlerTest.cpp
@@ -410,7 +410,7 @@ void TagListHandlerTest::TestOnTagListContextCommandInvalidIndex() {
 
 void TagListHandlerTest::TestSortTags() {
 	// 独自ルールソートのテスト
-	std::vector<std::string> tags = { "1girl", "solo", "long hair", "looking at viewer", "red eyes", "dress", "white dress", "fruit", "black hair", "black dress" };
+	std::vector<std::string> tags = { "1girl", "solo", "1girl", "long hair", "looking at viewer", "red eyes", "dress", "white dress", "fruit", "black hair", "black dress" };
 	TagListHandler::SyncTagList(reinterpret_cast<BooruPrompter*>(m_mockPrompter), tags);
 	TagListHandler::SortTags(reinterpret_cast<BooruPrompter*>(m_mockPrompter));
 	// 結果がカスタム依存になったので一旦テストをキャンセル


### PR DESCRIPTION
fix #34 